### PR TITLE
fix: Handle skipped jobs in CI Pipeline Status check

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -283,9 +283,11 @@ jobs:
           echo "  Deployment: ${{ needs.deploy.result }}"
           echo ""
 
-          if [[ "${{ needs.bulletin-board-tests.result }}" == "success" ]] && \
-             [[ "${{ needs.docker-build.result }}" == "success" ]] && \
-             [[ "${{ needs.integration-tests.result }}" == "success" ]]; then
+          # Check if all required jobs either succeeded or were skipped
+          # Skipped jobs are acceptable (e.g., when only workflow files change)
+          if [[ "${{ needs.bulletin-board-tests.result }}" =~ ^(success|skipped)$ ]] && \
+             [[ "${{ needs.docker-build.result }}" =~ ^(success|skipped)$ ]] && \
+             [[ "${{ needs.integration-tests.result }}" =~ ^(success|skipped)$ ]]; then
             echo "✅ Pipeline completed successfully!"
           else
             echo "❌ Pipeline has failures. Please check the logs."


### PR DESCRIPTION
## Summary
- Fixed CI Pipeline Status job failing when dependent jobs are skipped
- Updated condition to accept both 'success' and 'skipped' states as valid outcomes

## Problem
The Main CI Pipeline was failing when only workflow files changed because:
1. Jobs like `bulletin-board-tests`, `docker-build`, and `integration-tests` are conditionally run based on file changes
2. When these jobs are skipped (no relevant files changed), their result is "skipped"
3. The CI Pipeline Status job was only checking for "success", causing it to fail

## Solution
Modified the final status check to use regex pattern matching that accepts both "success" and "skipped" states. This allows the pipeline to complete successfully when jobs are appropriately skipped.

## Test Plan
- [x] Identified the root cause from failed workflow run
- [x] Applied fix to handle skipped jobs
- [ ] PR validation will test the fix with the updated workflow

Fixes: https://github.com/AndrewAltimit/AgentSocial/actions/runs/17037998723

🤖 Generated with [Claude Code](https://claude.ai/code)