### PR TITLE
fix: Fix Docker image naming in CI workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -170,10 +170,10 @@ jobs:
 
           # Tag for registry (repository names must be lowercase)
           OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          docker tag agentsocial_bulletin-web:latest ghcr.io/${OWNER_LOWER}/agentsocial-bulletin-web:latest
-          docker tag agentsocial_bulletin-web:latest ghcr.io/${OWNER_LOWER}/agentsocial-bulletin-web:${{ github.sha }}
-          docker tag agentsocial_bulletin-collector:latest ghcr.io/${OWNER_LOWER}/agentsocial-bulletin-collector:latest
-          docker tag agentsocial_bulletin-collector:latest ghcr.io/${OWNER_LOWER}/agentsocial-bulletin-collector:${{ github.sha }}
+          docker tag agentsocial-bulletin-web:latest ghcr.io/${OWNER_LOWER}/agentsocial-bulletin-web:latest
+          docker tag agentsocial-bulletin-web:latest ghcr.io/${OWNER_LOWER}/agentsocial-bulletin-web:${{ github.sha }}
+          docker tag agentsocial-bulletin-collector:latest ghcr.io/${OWNER_LOWER}/agentsocial-bulletin-collector:latest
+          docker tag agentsocial-bulletin-collector:latest ghcr.io/${OWNER_LOWER}/agentsocial-bulletin-collector:${{ github.sha }}
 
           # Push to registry
           docker push ghcr.io/${OWNER_LOWER}/agentsocial-bulletin-web:latest


### PR DESCRIPTION
## Summary

- Fixed Docker image naming mismatch in main-ci.yml workflow that was causing CI pipeline failures
- Changed from underscore notation (`agentsocial_bulletin-web`) to hyphen notation (`agentsocial-bulletin-web`) to match Docker Compose's actual naming convention
- Auto-formatted 15 Python files in the bulletin_board package to comply with Black formatting standards

## Problem

The CI pipeline was failing with the error:
```
Error response from daemon: No such image: agentsocial_bulletin-web:latest
```

This occurred because Docker Compose creates images with hyphens in their names, but the CI workflow was trying to tag images using underscores.

## Solution

Updated `.github/workflows/main-ci.yml` lines 173-176 to use the correct image names with hyphens.

## Test Plan

- [x] Verified Docker images exist locally with `docker images | grep bulletin`
- [x] Ran formatting checks locally with `./automation/ci-cd/run-ci.sh format`
- [ ] CI pipeline should pass after merge

🤖 Generated with [Claude Code](https://claude.ai/code)